### PR TITLE
Some build improvements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
-Dockerfile
-go.mod
-go.sum
-main.go
-Makefile
+*
+!.git/
+!Makefile
+!go.mod
+!go.sum
+!**/*.go

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 FROM alpine:latest AS builder
 
 RUN apk add --no-cache make go git 
-COPY . ./ses-smtpd-proxy
-WORKDIR /ses-smtpd-proxy
+COPY . ./app
+WORKDIR /app
 RUN make ses-smtpd-proxy
 
 FROM alpine:latest
 
 RUN apk add --no-cache ca-certificates
-COPY --from=builder ses-smtpd-proxy /
+COPY --from=builder /app/ses-smtpd-proxy /
 
 ENTRYPOINT [ "/ses-smtpd-proxy" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,13 @@
+FROM alpine:latest AS builder
+
+RUN apk add --no-cache make go git 
+COPY . ./ses-smtpd-proxy
+WORKDIR /ses-smtpd-proxy
+RUN make ses-smtpd-proxy
+
 FROM alpine:latest
 
 RUN apk add --no-cache ca-certificates
-ADD ses-smtpd-proxy /
+COPY --from=builder ses-smtpd-proxy /
 
-CMD [ "/ses-smtpd-proxy" ]
+ENTRYPOINT [ "/ses-smtpd-proxy" ]

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 BINARY ?= ses-smtpd-proxy
-DOCKER_IMAGE ?= docker.crute.me/ses-email-proxy:latest
+DOCKER_REGISTRY ?= docker.crute.me	
+DOCKER_IMAGE_NAME ?= ses-email-proxy
+DOCKER_TAG ?= latest
+DOCKER_IMAGE ?= ${DOCKER_REGISTRY}/${DOCKER_IMAGE_NAME}:${DOCKER_TAG}
 
 $(BINARY): main.go go.sum smtpd/smtpd.go
 	CGO_ENABLED=0 go build \
@@ -7,7 +10,7 @@ $(BINARY): main.go go.sum smtpd/smtpd.go
 		-o $@ $<
 
 .PHONY: docker
-docker: $(BINARY)
+docker:
 	docker build -t $(DOCKER_IMAGE) .
 
 .PHONY: publish


### PR DESCRIPTION
Thanks so much! Then has allowed me to get emails working on older SQL Servers that don't work with new TLS 1.2 SES requirements. I've made some helpful changes I'd like to contribute.

- Set DOCKER_IMAGE from env vars as documented in [README.md](https://github.com/mcrute/ses-smtpd-proxy?tab=readme-ov-file#building). 
- Updated Dockerfile to compile in docker then build container. When I compiled on MacOS, it didn't run on Alpine. This is a convenient way to ensure runnable container. 
- Changed CMD to ENTRYPOINT so parameters can more easily be passed when using Docker.