### PR TITLE
Faster builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 *
-!.git/
 !Makefile
 !go.mod
 !go.sum

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,12 @@
-FROM alpine:latest AS builder
-
-RUN apk add --no-cache make go git 
-COPY . ./app
-WORKDIR /app
-RUN make ses-smtpd-proxy
+FROM golang:1.23-alpine AS builder
+ARG VERSION
+RUN apk add --no-cache make 
+COPY . .
+RUN VERSION=$VERSION make ses-smtpd-proxy
 
 FROM alpine:latest
 
 RUN apk add --no-cache ca-certificates
-COPY --from=builder /app/ses-smtpd-proxy /
+COPY --from=builder /go/ses-smtpd-proxy /
 
 ENTRYPOINT [ "/ses-smtpd-proxy" ]

--- a/Makefile
+++ b/Makefile
@@ -3,15 +3,16 @@ DOCKER_REGISTRY ?= docker.crute.me
 DOCKER_IMAGE_NAME ?= ses-email-proxy
 DOCKER_TAG ?= latest
 DOCKER_IMAGE ?= ${DOCKER_REGISTRY}/${DOCKER_IMAGE_NAME}:${DOCKER_TAG}
+VERSION ?= $(shell git describe --long --tags --dirty --always)
 
 $(BINARY): main.go go.sum smtpd/smtpd.go
 	CGO_ENABLED=0 go build \
-		-ldflags "-X main.version=$(shell git describe --long --tags --dirty --always)"  \
+		-ldflags "-X main.version=$(VERSION)"  \
 		-o $@ $<
 
 .PHONY: docker
 docker:
-	docker build -t $(DOCKER_IMAGE) .
+	docker build --build-arg VERSION=$(VERSION) -t $(DOCKER_IMAGE) .
 
 .PHONY: publish
 publish: docker


### PR DESCRIPTION
Thanks for the inspiration! 

- Leverage official golang container as builder image (no more `apk add go`)
- Pass in `VERSION` to avoid `.git/` and `apk add git` as dependencies