### PR TITLE
Add deployment manifests and AWS IAM example policy

### DIFF
--- a/deploy/aws/iam.json
+++ b/deploy/aws/iam.json
@@ -1,0 +1,12 @@
+{
+    "Statement": [
+        {
+            "Action": [
+                "ses:SendRawEmail"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        }
+    ],
+    "Version": "2012-10-17"
+}

--- a/deploy/kubernetes/kustomize/deployment.yaml
+++ b/deploy/kubernetes/kustomize/deployment.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ses-smtpd-proxy
+spec:
+  selector:
+    matchLabels:
+      app: ses-smtpd-proxy
+  template:
+    metadata:
+      labels:
+        app: ses-smtpd-proxy
+    spec:
+      terminationGracePeriodSeconds: 10
+      serviceAccountName: ses-smtpd-proxy
+      containers:
+      - name: ses-smtpd-proxy
+        image: quay.io/swimlane/ses-smtpd-proxy
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 2500
+        resources: {}

--- a/deploy/kubernetes/kustomize/deployment.yaml
+++ b/deploy/kubernetes/kustomize/deployment.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: ses-smtpd-proxy
       containers:
       - name: ses-smtpd-proxy
-        image: quay.io/swimlane/ses-smtpd-proxy
+        image: mcrute/ses-smtpd-proxy
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 2500

--- a/deploy/kubernetes/kustomize/kustomization.yaml
+++ b/deploy/kubernetes/kustomize/kustomization.yaml
@@ -2,9 +2,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-images:
-  - name: quay.io/swimlane/ses-smtpd-proxy
-    newTag: 0.2.0
+# images:
+#   - name: mcrute/ses-smtpd-proxy
+#     newTag: 0.2.0
 
 resources:
 - ./deployment.yaml

--- a/deploy/kubernetes/kustomize/kustomization.yaml
+++ b/deploy/kubernetes/kustomize/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+images:
+  - name: quay.io/swimlane/ses-smtpd-proxy
+    newTag: 0.2.0
+
+resources:
+- ./deployment.yaml
+- ./service.yaml
+- ./serviceaccount.yaml

--- a/deploy/kubernetes/kustomize/service.yaml
+++ b/deploy/kubernetes/kustomize/service.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ses-smtpd-proxy
+spec:
+  selector:
+    app: ses-smtpd-proxy
+  type: ClusterIP
+  ports:
+  - protocol: TCP
+    port: 2500
+    targetPort: 2500

--- a/deploy/kubernetes/kustomize/serviceaccount.yaml
+++ b/deploy/kubernetes/kustomize/serviceaccount.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ses-smtpd-proxy
+  annotations:
+    # Required if using EKS IRSA for authentication.
+    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/ses-smtpd-proxy


### PR DESCRIPTION
I am running a POC for this locally and figured someone else may find these useful in the future. The image tag referenced in the deployment is publicly available but I cannot guarantee that it always will be.